### PR TITLE
Tweak behavior of timeline plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{js,ts}]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.*.swp
+node_modules
+main.js

--- a/src/block.ts
+++ b/src/block.ts
@@ -9,7 +9,7 @@ export class TimelineProcessor {
 
 		let lines = source.trim()
 		let elCanvas = el.createDiv({ cls: 'timeline' });
-        
+
 		if (!lines) return;
 		// Parse the tags to search for the proper files
 		let tagList = lines.split(";");
@@ -20,7 +20,7 @@ export class TimelineProcessor {
 			// if no files valid for timeline
 			return;
 		}
-		// Keep only the files that have the time info 
+		// Keep only the files that have the time info
 		let timeline = document.createElement('div');
 		timeline.setAttribute('class', 'timeline')
 		let timelineNotes = [];
@@ -31,31 +31,36 @@ export class TimelineProcessor {
 			const domparser = new DOMParser()
 			const doc = domparser.parseFromString(await appVault.read(fileList[i]), 'text/html')
 			let timelineData = doc.getElementsByClassName('ob-timelines')
-			if (!(timelineData[0] instanceof HTMLElement)) {
-				continue;
-			}
+			for(var j = 0; j < timelineData.length; j++) {
+				let element = timelineData[j];
+				if ( ! (element instanceof HTMLElement) ) {
+					continue;
+				}
 
-			let noteId;
-			// check if a valid date is specified
-			if (timelineData[0].dataset.date[0] == '-') {
-				// if it is a negative year
-				noteId = +timelineData[0].dataset.date.substring(1, timelineData[0].dataset.date.length).split('-').join('') * -1;
-			} else {
-				noteId = +timelineData[0].dataset.date.split('-').join('');
-			}
-			if (!Number.isInteger(noteId)) {
-				continue;
-			}
-			// if not title is specified use note name
-			let noteTitle = timelineData[0].dataset.title ?? fileList[i].name;
+				let noteId;
+				// check if a valid date is specified
+				if (element.dataset.date[0] == '-') {
+					// if it is a negative year
+					noteId = +element.dataset.date.substring(1, element.dataset.date.length).split('-').join('') * -1;
+				} else {
+					noteId = +element.dataset.date.split('-').join('');
+				}
+				if (!Number.isInteger(noteId)) {
+					continue;
+				}
+				// if not title is specified use note name
+				let noteTitle = element.dataset.title ?? fileList[i].name;
+				let noteClass = element.dataset.class ?? "";
+				let notePath = '/' + fileList[i].path;
 
-			if (!timelineNotes[noteId]) {
-				timelineNotes[noteId] = [];
-				timelineNotes[noteId][0] = [timelineData[0].dataset.date, noteTitle, timelineData[0].dataset.img, timelineData[0].innerHTML, fileList[i].path];
-				timelineDates.push(noteId);
-			} else {
-				// if note_id already present append to it
-				timelineNotes[noteId][timelineNotes[noteId].length] = [timelineData[0].dataset.date, noteTitle, timelineData[0].dataset.img, timelineData[0].innerHTML, fileList[i].path];
+				if (!timelineNotes[noteId]) {
+					timelineNotes[noteId] = [];
+					timelineNotes[noteId][0] = [element.dataset.date, noteTitle, element.dataset.img, element.innerHTML, notePath, noteClass];
+					timelineDates.push(noteId);
+				} else {
+					// if note_id already present append to it
+					timelineNotes[noteId][timelineNotes[noteId].length] = [element.dataset.date, noteTitle, element.dataset.img, element.innerHTML, notePath, noteClass];
+				}
 			}
 		}
 
@@ -92,9 +97,12 @@ export class TimelineProcessor {
 				if (getElement(timelineNotes, timelineDates[i], j, 2)) {
 					noteCard.createDiv({ cls: 'thumb', attr: { style: `background-image: url(${getElement(timelineNotes, timelineDates[i], j, 2)});` } });
 				}
+				if (getElement(timelineNotes, timelineDates[i], j, 5)) {
+					noteCard.addClass(getElement(timelineNotes, timelineDates[i], j, 5));
+				}
 
-				noteCard.createEl('article').createEl('h3').createEl('a', { cls: 'internal-link', attr: { href: `${getElement(timelineNotes, timelineDates[i], j, 4)}` }, text: getElement(timelineNotes, timelineDates[i], j, 1).replace(/([""``''])/g, '\\$1') })
-				noteCard.createEl('p', { text: getElement(timelineNotes, timelineDates[i], j, 3).replace(/([""``''])/g, '\\$1') })
+				noteCard.createEl('article').createEl('h3').createEl('a', { cls: 'internal-link', attr: { href: `${getElement(timelineNotes, timelineDates[i], j, 4)}` }, text: getElement(timelineNotes, timelineDates[i], j, 1) })
+				noteCard.createEl('p', { text: getElement(timelineNotes, timelineDates[i], j, 3) })
 			}
 		}
 


### PR DESCRIPTION
Just sharing back what I tweaked, in case you want to steal any of it: 

* Do not replace quote characters. Apostrophes were showing up escaped as `\'` in card titles. Avoiding the explicit replacement seems not to confuse anything, but I haven't tried quoted speech.
* Support an additional css class per card, so that they can be styled differently (an additional/optional attribute in the span)
* Support multiple spans in the same document
* Use absolute repository path for card links so that timelines can be located anywhere and links still work.

I'd changed the original main.ts to replace the content between HTML comment tags.. but that isn't necessary (though part of me will miss having the ordered index checked into git.. ).

THANK YOU for this plugin. ;)