### PR TITLE
bring back render

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{js,ts}]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,5 @@ export const DEFAULT_SETTINGS: TimelinesSettings = {
     timelineTag: 'timeline',
     sortDirection: true
 }
+
+export const RENDER_TIMELINE: RegExp = /<!--TIMELINE BEGIN tags=['"]([^"]*?)['"]-->(.*)+?<!--TIMELINE END-->/im;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import type { TimelinesSettings } from './types'
 import { DEFAULT_SETTINGS } from './constants'
 import { TimelinesSettingTab } from './settings'
 import { TimelineProcessor } from './block'
-import { Plugin } from 'obsidian';
+import { Plugin, MarkdownView } from 'obsidian';
 
 export default class TimelinesPlugin extends Plugin {
 	settings: TimelinesSettings;
@@ -16,6 +16,18 @@ export default class TimelinesPlugin extends Plugin {
 		this.registerMarkdownCodeBlockProcessor('timeline', async (source, el, ctx) => {
 			const proc = new TimelineProcessor();
 			await proc.run(source, el, this.settings, this.app.vault.getMarkdownFiles(), this.app.metadataCache, this.app.vault);
+		});
+
+		this.addCommand({
+			id: "render-timeline",
+			name: "Render Timeline",
+			callback: async () => {
+				const proc = new TimelineProcessor();
+				let view = this.app.workspace.getActiveViewOfType(MarkdownView);
+				if (view) {
+					await proc.insertTimelineIntoCurrentNote(view, this.settings, this.app.vault.getMarkdownFiles(), this.app.metadataCache, this.app.vault);
+				}
+			}
 		});
 
 		this.addSettingTab(new TimelinesSettingTab(this.app, this));

--- a/styles.css
+++ b/styles.css
@@ -166,3 +166,12 @@
     flex-direction: column;
     justify-content: space-between;
 }
+
+.timeline-rendered {
+  color: var(--text-faint);
+  font-size: smaller;
+}
+
+.timeline-rendered::before {
+  content: "Updated: ";
+}


### PR DESCRIPTION
This brings back the command driven timeline action to render a timeline statically.

As an alternative to using a rendering block like this: 

<pre><code>```timeline
tag1;tag2
```</code></pre>

You use a comment block like this: 

```html
<!--TIMELINE BEGIN tags='tag1;tag2'--><!--TIMELINE END-->
```

When you use the "Render Timeline" action, any content between those two comment blocks will be replaced with the rendered timeline (you don't need to select it first). 

---

Aside: Most IDEs and editors understand [.editorconfig files](https://editorconfig.org/). I use it to make sure I use tabs instead of spaces in this project (regardless of whatever settings I may have elsewhere). 
