### PR TITLE
Added 'Era' suffix; Remove '.md' from titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,22 @@ The note will be ignored in the following cases:
   - If an invalid url is given (an empty black section will be seen for that note card)
   - Currently only `http` & `absolute local path` will render, in the current obsidian release of `v0.10.13` obsidian links for background images are blocked from rendering, hopefully it is promised that this will be removed in the upcuming release. 
 
+### Era:
+  - Optional
+  - Adds this text to the date span in the timeline as an era designation. Useful for fictional calendars.
+  - Applied after the date is formatted. So `2300-00-00-00` with the era set to `AB` would display `2300 AB`.
+
 ### CSS Class:
   - Optional
   - Adds the applied css class to the note card associated with this span info block
 
 
 ## Release Notes
+
+### v0.3.3
+- Added optional span attribute 'era', allowing an era suffix to be displayed on the timeline.
+- Updated `package.json` to latest obsidian API standard.atch
+- Removes the `.md` extension when auto-filling the title 
 
 ### v0.2.1 
 - Remove escaping of `quotes / double quotes and ticks` from title and text (no longer needed)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "Timelines",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "Timelines",
-            "version": "0.3.2",
+            "version": "0.3.3",
             "license": "MIT",
             "dependencies": {
                 "rollup-plugin-styles": "^3.14.1",
@@ -17,33 +17,42 @@
                 "@rollup/plugin-node-resolve": "^9.0.0",
                 "@rollup/plugin-typescript": "^6.0.0",
                 "@types/node": "^14.14.2",
-                "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+                "obsidian": "^0.12.11",
                 "rollup": "^2.32.1",
                 "tslib": "^2.0.3",
                 "typescript": "^4.0.3"
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-            "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+            "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
             "dependencies": {
-                "@babel/highlight": "^7.12.13"
+                "@babel/highlight": "^7.14.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+            "version": "7.14.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+            "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+            "engines": {
+                "node": ">=6.9.0"
+            }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.13.10",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-            "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.12.11",
+                "@babel/helper-validator-identifier": "^7.14.5",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@egjs/hammerjs": {
@@ -74,6 +83,9 @@
             },
             "engines": {
                 "node": ">= 8.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.22.0"
             }
         },
         "node_modules/@rollup/plugin-node-resolve": {
@@ -91,6 +103,9 @@
             },
             "engines": {
                 "node": ">= 10.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0"
             }
         },
         "node_modules/@rollup/plugin-typescript": {
@@ -104,6 +119,11 @@
             },
             "engines": {
                 "node": ">=8.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.14.0",
+                "tslib": "*",
+                "typescript": ">=3.4.0"
             }
         },
         "node_modules/@rollup/pluginutils": {
@@ -118,6 +138,9 @@
             },
             "engines": {
                 "node": ">= 8.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0"
             }
         },
         "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
@@ -127,26 +150,26 @@
             "dev": true
         },
         "node_modules/@types/codemirror": {
-            "version": "0.0.98",
-            "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.98.tgz",
-            "integrity": "sha512-cbty5LPayy2vNSeuUdjNA9tggG+go5vAxmnLDRWpiZI5a+RDBi9dlozy4/jW/7P/gletbBWbQREEa7A81YxstA==",
+            "version": "0.0.108",
+            "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
+            "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
             "dev": true,
             "dependencies": {
                 "@types/tern": "*"
             }
         },
         "node_modules/@types/cssnano": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/cssnano/-/cssnano-4.0.0.tgz",
-            "integrity": "sha512-BC/2ibKZfPIaBLBNzkitdW1IvvX/LKW6/QXGc4Su/tAJ7mQ3f2CKBuGCCKaqGAnoKwzfuC7G/recpkARwdOwuA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/cssnano/-/cssnano-4.0.1.tgz",
+            "integrity": "sha512-hGOroxRTBkYl5gSBRJOffhV4+io+Y2bFX1VP7LgKEVHJt/LPPJaWUIuDAz74Vlp7l7hCDZfaDi7iPxwNwuVA4Q==",
             "dependencies": {
                 "postcss": "5 - 7"
             }
         },
         "node_modules/@types/cssnano/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -186,15 +209,15 @@
             "dev": true
         },
         "node_modules/@types/hammerjs": {
-            "version": "2.0.39",
-            "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.39.tgz",
-            "integrity": "sha512-lYR2Y/tV2ujpk/WyUc7S0VLI0a9hrtVIN9EwnrNo5oSEJI2cK2/XrgwOQmXLL3eTulOESvh9qP6si9+DWM9cOA==",
+            "version": "2.0.40",
+            "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.40.tgz",
+            "integrity": "sha512-VbjwR1fhsn2h2KXAY4oy1fm7dCxaKy0D+deTb8Ilc3Eo3rc5+5eA4rfYmZaHgNJKxVyI0f6WIXzO2zLkVmQPHA==",
             "peer": true
         },
         "node_modules/@types/node": {
-            "version": "14.14.25",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-            "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
+            "version": "14.17.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+            "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ==",
             "dev": true
         },
         "node_modules/@types/parse-json": {
@@ -203,9 +226,9 @@
             "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
         },
         "node_modules/@types/q": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
-            "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
+            "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
         },
         "node_modules/@types/resolve": {
             "version": "1.17.1",
@@ -217,9 +240,9 @@
             }
         },
         "node_modules/@types/tern": {
-            "version": "0.23.3",
-            "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
-            "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
+            "version": "0.23.4",
+            "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+            "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*"
@@ -258,9 +281,9 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
         "node_modules/boolbase": {
@@ -279,15 +302,15 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-            "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+            "version": "4.16.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
-                "electron-to-chromium": "^1.3.649",
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.70"
+                "node-releases": "^1.1.71"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -307,6 +330,9 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/call-bind": {
@@ -371,9 +397,13 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001205",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz",
-            "integrity": "sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og=="
+            "version": "1.0.30001247",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz",
+            "integrity": "sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/browserslist"
+            }
         },
         "node_modules/chalk": {
             "version": "2.4.2",
@@ -402,12 +432,12 @@
             }
         },
         "node_modules/color": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-            "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+            "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
             "dependencies": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.4"
+                "color-convert": "^1.9.3",
+                "color-string": "^1.6.0"
             }
         },
         "node_modules/color-convert": {
@@ -424,9 +454,9 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "node_modules/color-string": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-            "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+            "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
             "dependencies": {
                 "color-name": "^1.0.0",
                 "simple-swizzle": "^0.2.2"
@@ -497,9 +527,9 @@
             }
         },
         "node_modules/css-declaration-sorter/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -597,12 +627,12 @@
             "peer": true
         },
         "node_modules/cssnano": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
-            "integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.11.tgz",
+            "integrity": "sha512-6gZm2htn7xIPJOHY824ERgj8cNPgPxyCSnkXc4v7YvNW+TdVfzgngHcEhy/8D11kUWRUMbke+tC+AUcUsnMz2g==",
             "dependencies": {
                 "cosmiconfig": "^5.0.0",
-                "cssnano-preset-default": "^4.0.7",
+                "cssnano-preset-default": "^4.0.8",
                 "is-resolvable": "^1.0.0",
                 "postcss": "^7.0.0"
             },
@@ -611,9 +641,9 @@
             }
         },
         "node_modules/cssnano-preset-default": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
-            "integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.8.tgz",
+            "integrity": "sha512-LdAyHuq+VRyeVREFmuxUZR1TXjQm8QQU/ktoo/x7bz+SdOge1YKc5eMN6pRW7YWBmyq59CqYba1dJ5cUukEjLQ==",
             "dependencies": {
                 "css-declaration-sorter": "^4.0.1",
                 "cssnano-util-raw-cache": "^4.0.1",
@@ -643,7 +673,7 @@
                 "postcss-ordered-values": "^4.1.2",
                 "postcss-reduce-initial": "^4.0.3",
                 "postcss-reduce-transforms": "^4.0.2",
-                "postcss-svgo": "^4.0.2",
+                "postcss-svgo": "^4.0.3",
                 "postcss-unique-selectors": "^4.0.1"
             },
             "engines": {
@@ -651,9 +681,9 @@
             }
         },
         "node_modules/cssnano-preset-default/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -714,9 +744,9 @@
             }
         },
         "node_modules/cssnano-util-raw-cache/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -796,9 +826,9 @@
             }
         },
         "node_modules/cssnano/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -916,10 +946,12 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
             "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-            "funding": [{
-                "type": "github",
-                "url": "https://github.com/sponsors/fb55"
-            }]
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ]
         },
         "node_modules/domelementtype": {
             "version": "1.3.1",
@@ -947,9 +979,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.707",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.707.tgz",
-            "integrity": "sha512-BqddgxNPrcWnbDdJw7SzXVzPmp+oiyjVrc7tkQVaznPGSS9SKZatw6qxoP857M+HbOyyqJQwYQtsuFIMSTNSZA=="
+            "version": "1.3.786",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.786.tgz",
+            "integrity": "sha512-AmvbLBj3hepRk8v/DHrFF8gINxOFfDbrn6Ts3PcK46/FBdQb5OMmpamSpZQXSkfi77FfBzYtQtAk+00LCLYMVw=="
         },
         "node_modules/entities": {
             "version": "2.2.0",
@@ -968,9 +1000,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-            "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
@@ -980,14 +1012,14 @@
                 "has-symbols": "^1.0.2",
                 "is-callable": "^1.2.3",
                 "is-negative-zero": "^2.0.1",
-                "is-regex": "^1.1.2",
-                "is-string": "^1.0.5",
-                "object-inspect": "^1.9.0",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.2",
                 "string.prototype.trimend": "^1.0.4",
                 "string.prototype.trimstart": "^1.0.4",
-                "unbox-primitive": "^1.0.0"
+                "unbox-primitive": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1082,6 +1114,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "hasInstallScript": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -1109,9 +1142,9 @@
             }
         },
         "node_modules/glob": {
-            "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "version": "7.1.7",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -1123,6 +1156,9 @@
             },
             "engines": {
                 "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/graceful-fs": {
@@ -1182,11 +1218,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
             "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
-        },
-        "node_modules/html-comment-regex": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
-            "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
         },
         "node_modules/icss-utils": {
             "version": "5.1.0",
@@ -1249,19 +1280,19 @@
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "node_modules/is-bigint": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-            "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-boolean-object": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-            "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
             "dependencies": {
-                "call-bind": "^1.0.0"
+                "call-bind": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1295,17 +1326,20 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-            "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+            "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
             "dependencies": {
                 "has": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-date-object": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1339,9 +1373,9 @@
             }
         },
         "node_modules/is-number-object": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-            "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1367,12 +1401,12 @@
             }
         },
         "node_modules/is-regex": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-            "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+            "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
             "dependencies": {
                 "call-bind": "^1.0.2",
-                "has-symbols": "^1.0.1"
+                "has-symbols": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1387,9 +1421,9 @@
             "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
         },
         "node_modules/is-string": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-            "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1397,23 +1431,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-svg": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
-            "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
-            "dependencies": {
-                "html-comment-regex": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/is-symbol": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
             "dependencies": {
-                "has-symbols": "^1.0.1"
+                "has-symbols": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1496,19 +1519,19 @@
             "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
         },
         "node_modules/mime-db": {
-            "version": "1.47.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-            "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+            "version": "1.48.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+            "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "2.1.30",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
-            "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+            "version": "2.1.31",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+            "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
             "dependencies": {
-                "mime-db": "1.47.0"
+                "mime-db": "1.48.0"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -1546,15 +1569,14 @@
             "version": "2.29.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
             "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-            "peer": true,
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/nanoid": {
-            "version": "3.1.22",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-            "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+            "version": "3.1.23",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -1563,9 +1585,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "1.1.71",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-            "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
+            "version": "1.1.73",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+            "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
         },
         "node_modules/normalize-url": {
             "version": "3.3.0",
@@ -1584,9 +1606,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-            "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -1633,14 +1655,13 @@
             }
         },
         "node_modules/object.values": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-            "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+            "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.2",
-                "has": "^1.0.3"
+                "es-abstract": "^1.18.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1650,11 +1671,13 @@
             }
         },
         "node_modules/obsidian": {
-            "resolved": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-            "integrity": "sha512-1juDiM1gXUzfDhh4JgKNwJ2EVJWq3U8sI7AtLqGWO5vAeakEud4A08+EF7S+Y9TpmQaWUQ4CD+38PjgNYA75OA==",
+            "version": "0.12.11",
+            "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.11.tgz",
+            "integrity": "sha512-Kv4m1n4nfd17FzpqHZfqFS2YZAyY+cxAUM7/5jqh1bmbPlmKoNd1XJZC7o9KvkXfTCxALiXfGRdrjHB+GUFAEA==",
             "dev": true,
             "dependencies": {
-                "@types/codemirror": "0.0.98"
+                "@types/codemirror": "0.0.108",
+                "moment": "2.29.1"
             }
         },
         "node_modules/once": {
@@ -1738,9 +1761,9 @@
             }
         },
         "node_modules/path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -1751,21 +1774,24 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
             "engines": {
                 "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/postcss": {
-            "version": "8.2.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-            "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+            "version": "8.3.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+            "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
             "dependencies": {
                 "colorette": "^1.2.2",
-                "nanoid": "^3.1.22",
-                "source-map": "^0.6.1"
+                "nanoid": "^3.1.23",
+                "source-map-js": "^0.6.2"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -1786,9 +1812,9 @@
             }
         },
         "node_modules/postcss-calc/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -1837,9 +1863,9 @@
             }
         },
         "node_modules/postcss-colormin/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -1890,9 +1916,9 @@
             }
         },
         "node_modules/postcss-convert-values/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -1942,9 +1968,9 @@
             }
         },
         "node_modules/postcss-discard-comments/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -1989,9 +2015,9 @@
             }
         },
         "node_modules/postcss-discard-duplicates/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2036,9 +2062,9 @@
             }
         },
         "node_modules/postcss-discard-empty/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2083,9 +2109,9 @@
             }
         },
         "node_modules/postcss-discard-overridden/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2133,9 +2159,9 @@
             }
         },
         "node_modules/postcss-merge-longhand/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2190,9 +2216,9 @@
             }
         },
         "node_modules/postcss-merge-rules/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2251,9 +2277,9 @@
             }
         },
         "node_modules/postcss-minify-font-values/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2306,9 +2332,9 @@
             }
         },
         "node_modules/postcss-minify-gradients/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2363,9 +2389,9 @@
             }
         },
         "node_modules/postcss-minify-params/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2418,9 +2444,9 @@
             }
         },
         "node_modules/postcss-minify-selectors/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2533,9 +2559,9 @@
             }
         },
         "node_modules/postcss-normalize-charset/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2582,9 +2608,9 @@
             }
         },
         "node_modules/postcss-normalize-display-values/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2637,9 +2663,9 @@
             }
         },
         "node_modules/postcss-normalize-positions/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2692,9 +2718,9 @@
             }
         },
         "node_modules/postcss-normalize-repeat-style/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2746,9 +2772,9 @@
             }
         },
         "node_modules/postcss-normalize-string/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2800,9 +2826,9 @@
             }
         },
         "node_modules/postcss-normalize-timing-functions/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2854,9 +2880,9 @@
             }
         },
         "node_modules/postcss-normalize-unicode/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2909,9 +2935,9 @@
             }
         },
         "node_modules/postcss-normalize-url/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -2962,9 +2988,9 @@
             }
         },
         "node_modules/postcss-normalize-whitespace/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -3016,9 +3042,9 @@
             }
         },
         "node_modules/postcss-ordered-values/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -3071,9 +3097,9 @@
             }
         },
         "node_modules/postcss-reduce-initial/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -3121,9 +3147,9 @@
             }
         },
         "node_modules/postcss-reduce-transforms/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -3162,13 +3188,11 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
-            "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
             "dependencies": {
                 "cssesc": "^3.0.0",
-                "indexes-of": "^1.0.1",
-                "uniq": "^1.0.1",
                 "util-deprecate": "^1.0.2"
             },
             "engines": {
@@ -3176,11 +3200,10 @@
             }
         },
         "node_modules/postcss-svgo": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
-            "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.3.tgz",
+            "integrity": "sha512-NoRbrcMWTtUghzuKSoIm6XV+sJdvZ7GZSc3wdBN0W19FTtp2ko8NqLsgoh/m9CzNhU3KLPvQmjIwtaNFkaFTvw==",
             "dependencies": {
-                "is-svg": "^3.0.0",
                 "postcss": "^7.0.0",
                 "postcss-value-parser": "^3.0.0",
                 "svgo": "^1.0.0"
@@ -3190,9 +3213,9 @@
             }
         },
         "node_modules/postcss-svgo/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -3244,9 +3267,9 @@
             }
         },
         "node_modules/postcss-unique-selectors/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -3284,14 +3307,6 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
             "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
         },
-        "node_modules/postcss/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/propagating-hammerjs": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-2.0.1.tgz",
@@ -3328,12 +3343,15 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.19.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-            "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
             "dependencies": {
-                "is-core-module": "^2.1.0",
+                "is-core-module": "^2.2.0",
                 "path-parse": "^1.0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/resolve-from": {
@@ -3355,9 +3373,9 @@
             "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
         },
         "node_modules/rollup": {
-            "version": "2.38.5",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.5.tgz",
-            "integrity": "sha512-VoWt8DysFGDVRGWuHTqZzT02J0ASgjVq/hPs9QcBOGMd7B+jfTr/iqMVEyOi901rE3xq+Deq66GzIT1yt7sGwQ==",
+            "version": "2.53.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.3.tgz",
+            "integrity": "sha512-79QIGP5DXz5ZHYnCPi3tLz+elOQi6gudp9YINdaJdjG0Yddubo6JRFUM//qCZ0Bap/GJrsUoEBVdSOc4AkMlRA==",
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -3365,7 +3383,7 @@
                 "node": ">=10.0.0"
             },
             "optionalDependencies": {
-                "fsevents": "~2.3.1"
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/rollup-plugin-styles": {
@@ -3400,18 +3418,15 @@
             }
         },
         "node_modules/rollup-plugin-styles/node_modules/@rollup/pluginutils": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
-            "integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+            "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
             "dependencies": {
                 "estree-walker": "^2.0.1",
                 "picomatch": "^2.2.2"
             },
             "engines": {
                 "node": ">= 8.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0"
             }
         },
         "node_modules/sax": {
@@ -3438,6 +3453,14 @@
             "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+            "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/sourcemap-codec": {
@@ -3510,9 +3533,9 @@
             }
         },
         "node_modules/stylehacks/node_modules/postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "7.0.36",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "source-map": "^0.6.1",
@@ -3601,14 +3624,14 @@
             "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
         },
         "node_modules/tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         },
         "node_modules/typescript": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -3675,9 +3698,9 @@
             }
         },
         "node_modules/uuid": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-            "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "peer": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
@@ -3708,9 +3731,9 @@
             }
         },
         "node_modules/vis-timeline": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/vis-timeline/-/vis-timeline-7.4.6.tgz",
-            "integrity": "sha512-U4InXbpSaSH8Ag91RRnrjsC4Mf6SXNfdeCqVI3E2G1UrEM890otLS14/VpRYBYJkwSrFCVS2lPntEJHnU2XwTQ==",
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/vis-timeline/-/vis-timeline-7.4.9.tgz",
+            "integrity": "sha512-+Mb829u4Jq9qPhh6EHAa7DRBEwXW0AclaXndxAC7e772oI5pMSAbhbKsQXsPYRPkf9vtac3/US+WPHJQYjGsRA==",
             "hasInstallScript": true,
             "funding": {
                 "type": "opencollective",
@@ -3722,7 +3745,7 @@
                 "keycharm": "^0.3.0 || ^0.4.0",
                 "moment": "^2.24.0",
                 "propagating-hammerjs": "^1.4.0 || ^2.0.0",
-                "uuid": "^3.4.0 || ^7.0.0",
+                "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0",
                 "vis-data": "^6.3.0 || ^7.0.0",
                 "vis-util": "^3.0.0 || ^4.0.0 || ^5.0.0",
                 "xss": "^1.0.0"
@@ -3767,9 +3790,9 @@
             "dev": true
         },
         "node_modules/xss": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
-            "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.9.tgz",
+            "integrity": "sha512-2t7FahYnGJys6DpHLhajusId7R0Pm2yTmuL0GV9+mV0ZlaLSnb2toBmppATfg5sWIhZQGlsTLoecSzya+l4EAQ==",
             "peer": true,
             "dependencies": {
                 "commander": "^2.20.3",
@@ -3793,24 +3816,24 @@
     },
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-            "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+            "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
             "requires": {
-                "@babel/highlight": "^7.12.13"
+                "@babel/highlight": "^7.14.5"
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+            "version": "7.14.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+            "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow=="
         },
         "@babel/highlight": {
-            "version": "7.13.10",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-            "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
             "requires": {
-                "@babel/helper-validator-identifier": "^7.12.11",
+                "@babel/helper-validator-identifier": "^7.14.5",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             }
@@ -3883,26 +3906,26 @@
             }
         },
         "@types/codemirror": {
-            "version": "0.0.98",
-            "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.98.tgz",
-            "integrity": "sha512-cbty5LPayy2vNSeuUdjNA9tggG+go5vAxmnLDRWpiZI5a+RDBi9dlozy4/jW/7P/gletbBWbQREEa7A81YxstA==",
+            "version": "0.0.108",
+            "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
+            "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
             "dev": true,
             "requires": {
                 "@types/tern": "*"
             }
         },
         "@types/cssnano": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/cssnano/-/cssnano-4.0.0.tgz",
-            "integrity": "sha512-BC/2ibKZfPIaBLBNzkitdW1IvvX/LKW6/QXGc4Su/tAJ7mQ3f2CKBuGCCKaqGAnoKwzfuC7G/recpkARwdOwuA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/cssnano/-/cssnano-4.0.1.tgz",
+            "integrity": "sha512-hGOroxRTBkYl5gSBRJOffhV4+io+Y2bFX1VP7LgKEVHJt/LPPJaWUIuDAz74Vlp7l7hCDZfaDi7iPxwNwuVA4Q==",
             "requires": {
                 "postcss": "5 - 7"
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -3931,15 +3954,15 @@
             "dev": true
         },
         "@types/hammerjs": {
-            "version": "2.0.39",
-            "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.39.tgz",
-            "integrity": "sha512-lYR2Y/tV2ujpk/WyUc7S0VLI0a9hrtVIN9EwnrNo5oSEJI2cK2/XrgwOQmXLL3eTulOESvh9qP6si9+DWM9cOA==",
+            "version": "2.0.40",
+            "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.40.tgz",
+            "integrity": "sha512-VbjwR1fhsn2h2KXAY4oy1fm7dCxaKy0D+deTb8Ilc3Eo3rc5+5eA4rfYmZaHgNJKxVyI0f6WIXzO2zLkVmQPHA==",
             "peer": true
         },
         "@types/node": {
-            "version": "14.14.25",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-            "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
+            "version": "14.17.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+            "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ==",
             "dev": true
         },
         "@types/parse-json": {
@@ -3948,9 +3971,9 @@
             "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
         },
         "@types/q": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
-            "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
+            "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
         },
         "@types/resolve": {
             "version": "1.17.1",
@@ -3962,9 +3985,9 @@
             }
         },
         "@types/tern": {
-            "version": "0.23.3",
-            "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
-            "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
+            "version": "0.23.4",
+            "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+            "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
             "dev": true,
             "requires": {
                 "@types/estree": "*"
@@ -3997,9 +4020,9 @@
             "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
         },
         "balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
         "boolbase": {
@@ -4018,15 +4041,15 @@
             }
         },
         "browserslist": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-            "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+            "version": "4.16.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
             "requires": {
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
-                "electron-to-chromium": "^1.3.649",
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.70"
+                "node-releases": "^1.1.71"
             }
         },
         "builtin-modules": {
@@ -4084,9 +4107,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001205",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz",
-            "integrity": "sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og=="
+            "version": "1.0.30001247",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz",
+            "integrity": "sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ=="
         },
         "chalk": {
             "version": "2.4.2",
@@ -4109,12 +4132,12 @@
             }
         },
         "color": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-            "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+            "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
             "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.4"
+                "color-convert": "^1.9.3",
+                "color-string": "^1.6.0"
             }
         },
         "color-convert": {
@@ -4131,9 +4154,9 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "color-string": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-            "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+            "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
             "requires": {
                 "color-name": "^1.0.0",
                 "simple-swizzle": "^0.2.2"
@@ -4195,9 +4218,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -4268,12 +4291,12 @@
             "peer": true
         },
         "cssnano": {
-            "version": "4.1.10",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
-            "integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.11.tgz",
+            "integrity": "sha512-6gZm2htn7xIPJOHY824ERgj8cNPgPxyCSnkXc4v7YvNW+TdVfzgngHcEhy/8D11kUWRUMbke+tC+AUcUsnMz2g==",
             "requires": {
                 "cosmiconfig": "^5.0.0",
-                "cssnano-preset-default": "^4.0.7",
+                "cssnano-preset-default": "^4.0.8",
                 "is-resolvable": "^1.0.0",
                 "postcss": "^7.0.0"
             },
@@ -4308,9 +4331,9 @@
                     }
                 },
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -4338,9 +4361,9 @@
             }
         },
         "cssnano-preset-default": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
-            "integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.8.tgz",
+            "integrity": "sha512-LdAyHuq+VRyeVREFmuxUZR1TXjQm8QQU/ktoo/x7bz+SdOge1YKc5eMN6pRW7YWBmyq59CqYba1dJ5cUukEjLQ==",
             "requires": {
                 "css-declaration-sorter": "^4.0.1",
                 "cssnano-util-raw-cache": "^4.0.1",
@@ -4370,14 +4393,14 @@
                 "postcss-ordered-values": "^4.1.2",
                 "postcss-reduce-initial": "^4.0.3",
                 "postcss-reduce-transforms": "^4.0.2",
-                "postcss-svgo": "^4.0.2",
+                "postcss-svgo": "^4.0.3",
                 "postcss-unique-selectors": "^4.0.1"
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -4418,9 +4441,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -4534,9 +4557,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.707",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.707.tgz",
-            "integrity": "sha512-BqddgxNPrcWnbDdJw7SzXVzPmp+oiyjVrc7tkQVaznPGSS9SKZatw6qxoP857M+HbOyyqJQwYQtsuFIMSTNSZA=="
+            "version": "1.3.786",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.786.tgz",
+            "integrity": "sha512-AmvbLBj3hepRk8v/DHrFF8gINxOFfDbrn6Ts3PcK46/FBdQb5OMmpamSpZQXSkfi77FfBzYtQtAk+00LCLYMVw=="
         },
         "entities": {
             "version": "2.2.0",
@@ -4552,9 +4575,9 @@
             }
         },
         "es-abstract": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-            "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
             "requires": {
                 "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
@@ -4564,14 +4587,14 @@
                 "has-symbols": "^1.0.2",
                 "is-callable": "^1.2.3",
                 "is-negative-zero": "^2.0.1",
-                "is-regex": "^1.1.2",
-                "is-string": "^1.0.5",
-                "object-inspect": "^1.9.0",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.2",
                 "string.prototype.trimend": "^1.0.4",
                 "string.prototype.trimstart": "^1.0.4",
-                "unbox-primitive": "^1.0.0"
+                "unbox-primitive": "^1.0.1"
             }
         },
         "es-to-primitive": {
@@ -4653,9 +4676,9 @@
             }
         },
         "glob": {
-            "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "version": "7.1.7",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -4709,11 +4732,6 @@
             "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
             "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
         },
-        "html-comment-regex": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
-            "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
-        },
         "icss-utils": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
@@ -4761,16 +4779,16 @@
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "is-bigint": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-            "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
         },
         "is-boolean-object": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-            "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
             "requires": {
-                "call-bind": "^1.0.0"
+                "call-bind": "^1.0.2"
             }
         },
         "is-callable": {
@@ -4792,17 +4810,17 @@
             }
         },
         "is-core-module": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-            "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+            "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
             "requires": {
                 "has": "^1.0.3"
             }
         },
         "is-date-object": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A=="
         },
         "is-directory": {
             "version": "0.3.1",
@@ -4821,9 +4839,9 @@
             "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
         },
         "is-number-object": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-            "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
         },
         "is-obj": {
             "version": "2.0.0",
@@ -4840,12 +4858,12 @@
             }
         },
         "is-regex": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-            "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+            "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
             "requires": {
                 "call-bind": "^1.0.2",
-                "has-symbols": "^1.0.1"
+                "has-symbols": "^1.0.2"
             }
         },
         "is-resolvable": {
@@ -4854,24 +4872,16 @@
             "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
         },
         "is-string": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-            "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
-        },
-        "is-svg": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
-            "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
-            "requires": {
-                "html-comment-regex": "^1.1.0"
-            }
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
         },
         "is-symbol": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
             "requires": {
-                "has-symbols": "^1.0.1"
+                "has-symbols": "^1.0.2"
             }
         },
         "js-tokens": {
@@ -4943,16 +4953,16 @@
             "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
         },
         "mime-db": {
-            "version": "1.47.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-            "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+            "version": "1.48.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+            "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
         },
         "mime-types": {
-            "version": "2.1.30",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
-            "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+            "version": "2.1.31",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+            "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
             "requires": {
-                "mime-db": "1.47.0"
+                "mime-db": "1.48.0"
             }
         },
         "minimatch": {
@@ -4980,18 +4990,17 @@
         "moment": {
             "version": "2.29.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-            "peer": true
+            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
         },
         "nanoid": {
-            "version": "3.1.22",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-            "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
+            "version": "3.1.23",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
         },
         "node-releases": {
-            "version": "1.1.71",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-            "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
+            "version": "1.1.73",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+            "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
         },
         "normalize-url": {
             "version": "3.3.0",
@@ -5007,9 +5016,9 @@
             }
         },
         "object-inspect": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-            "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
         },
         "object-keys": {
             "version": "1.1.1",
@@ -5038,22 +5047,23 @@
             }
         },
         "object.values": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-            "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+            "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.2",
-                "has": "^1.0.3"
+                "es-abstract": "^1.18.2"
             }
         },
         "obsidian": {
-            "version": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-            "integrity": "sha512-1juDiM1gXUzfDhh4JgKNwJ2EVJWq3U8sI7AtLqGWO5vAeakEud4A08+EF7S+Y9TpmQaWUQ4CD+38PjgNYA75OA==",
+            "version": "0.12.11",
+            "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.11.tgz",
+            "integrity": "sha512-Kv4m1n4nfd17FzpqHZfqFS2YZAyY+cxAUM7/5jqh1bmbPlmKoNd1XJZC7o9KvkXfTCxALiXfGRdrjHB+GUFAEA==",
             "dev": true,
             "requires": {
-                "@types/codemirror": "0.0.98"
+                "@types/codemirror": "0.0.108",
+                "moment": "2.29.1"
             }
         },
         "once": {
@@ -5113,9 +5123,9 @@
             "dev": true
         },
         "path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "path-type": {
             "version": "4.0.0",
@@ -5123,25 +5133,18 @@
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "picomatch": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
         },
         "postcss": {
-            "version": "8.2.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-            "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+            "version": "8.3.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+            "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
             "requires": {
                 "colorette": "^1.2.2",
-                "nanoid": "^3.1.22",
-                "source-map": "^0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                }
+                "nanoid": "^3.1.23",
+                "source-map-js": "^0.6.2"
             }
         },
         "postcss-calc": {
@@ -5155,9 +5158,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5192,9 +5195,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5231,9 +5234,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5269,9 +5272,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5302,9 +5305,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5335,9 +5338,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5368,9 +5371,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5404,9 +5407,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5447,9 +5450,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5491,9 +5494,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5532,9 +5535,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5575,9 +5578,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5616,9 +5619,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5691,9 +5694,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5726,9 +5729,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5767,9 +5770,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5808,9 +5811,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5848,9 +5851,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5888,9 +5891,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5928,9 +5931,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -5969,9 +5972,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -6008,9 +6011,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -6048,9 +6051,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -6089,9 +6092,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -6125,9 +6128,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -6155,31 +6158,28 @@
             }
         },
         "postcss-selector-parser": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
-            "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
             "requires": {
                 "cssesc": "^3.0.0",
-                "indexes-of": "^1.0.1",
-                "uniq": "^1.0.1",
                 "util-deprecate": "^1.0.2"
             }
         },
         "postcss-svgo": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
-            "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.3.tgz",
+            "integrity": "sha512-NoRbrcMWTtUghzuKSoIm6XV+sJdvZ7GZSc3wdBN0W19FTtp2ko8NqLsgoh/m9CzNhU3KLPvQmjIwtaNFkaFTvw==",
             "requires": {
-                "is-svg": "^3.0.0",
                 "postcss": "^7.0.0",
                 "postcss-value-parser": "^3.0.0",
                 "svgo": "^1.0.0"
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -6217,9 +6217,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -6270,11 +6270,11 @@
             }
         },
         "resolve": {
-            "version": "1.19.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-            "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
             "requires": {
-                "is-core-module": "^2.1.0",
+                "is-core-module": "^2.2.0",
                 "path-parse": "^1.0.6"
             }
         },
@@ -6294,11 +6294,11 @@
             "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
         },
         "rollup": {
-            "version": "2.38.5",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.5.tgz",
-            "integrity": "sha512-VoWt8DysFGDVRGWuHTqZzT02J0ASgjVq/hPs9QcBOGMd7B+jfTr/iqMVEyOi901rE3xq+Deq66GzIT1yt7sGwQ==",
+            "version": "2.53.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.3.tgz",
+            "integrity": "sha512-79QIGP5DXz5ZHYnCPi3tLz+elOQi6gudp9YINdaJdjG0Yddubo6JRFUM//qCZ0Bap/GJrsUoEBVdSOc4AkMlRA==",
             "requires": {
-                "fsevents": "~2.3.1"
+                "fsevents": "~2.3.2"
             }
         },
         "rollup-plugin-styles": {
@@ -6327,9 +6327,9 @@
             },
             "dependencies": {
                 "@rollup/pluginutils": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
-                    "integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+                    "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
                     "requires": {
                         "estree-walker": "^2.0.1",
                         "picomatch": "^2.2.2"
@@ -6361,6 +6361,11 @@
             "version": "0.7.3",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
             "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        },
+        "source-map-js": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+            "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
         },
         "sourcemap-codec": {
             "version": "1.4.8",
@@ -6417,9 +6422,9 @@
             },
             "dependencies": {
                 "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "requires": {
                         "chalk": "^2.4.2",
                         "source-map": "^0.6.1",
@@ -6485,14 +6490,14 @@
             "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
         },
         "tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         },
         "typescript": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
             "dev": true
         },
         "unbox-primitive": {
@@ -6543,9 +6548,9 @@
             }
         },
         "uuid": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-            "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "peer": true
         },
         "vendors": {
@@ -6561,9 +6566,9 @@
             "requires": {}
         },
         "vis-timeline": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/vis-timeline/-/vis-timeline-7.4.6.tgz",
-            "integrity": "sha512-U4InXbpSaSH8Ag91RRnrjsC4Mf6SXNfdeCqVI3E2G1UrEM890otLS14/VpRYBYJkwSrFCVS2lPntEJHnU2XwTQ==",
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/vis-timeline/-/vis-timeline-7.4.9.tgz",
+            "integrity": "sha512-+Mb829u4Jq9qPhh6EHAa7DRBEwXW0AclaXndxAC7e772oI5pMSAbhbKsQXsPYRPkf9vtac3/US+WPHJQYjGsRA==",
             "requires": {}
         },
         "vis-util": {
@@ -6592,9 +6597,9 @@
             "dev": true
         },
         "xss": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz",
-            "integrity": "sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.9.tgz",
+            "integrity": "sha512-2t7FahYnGJys6DpHLhajusId7R0Pm2yTmuL0GV9+mV0ZlaLSnb2toBmppATfg5sWIhZQGlsTLoecSzya+l4EAQ==",
             "peer": true,
             "requires": {
                 "commander": "^2.20.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "Timelines",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "description": "Create a timeline view of all notes with the specified combination of tags",
     "main": "main.js",
     "scripts": {
@@ -15,7 +15,7 @@
         "@rollup/plugin-node-resolve": "^9.0.0",
         "@rollup/plugin-typescript": "^6.0.0",
         "@types/node": "^14.14.2",
-        "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+        "obsidian": "^0.12.11",
         "rollup": "^2.32.1",
         "tslib": "^2.0.3",
         "typescript": "^4.0.3"

--- a/src/block.ts
+++ b/src/block.ts
@@ -98,11 +98,12 @@ export class TimelineProcessor {
 					continue;
 				}
 				// if not title is specified use note name
-				let noteTitle = event.dataset.title ?? file.name;
+				let noteTitle = event.dataset.title ?? file.name.replace(/\.md$/g, '');
 				let noteClass = event.dataset.class ?? "";
 				let notePath = '/' + file.path;
 				let type = event.dataset.type ?? "box";
 				let endDate = event.dataset.end ?? null;
+				let era = event.dataset.era ?? null;
 
 				if (!timelineNotes[noteId]) {
 					timelineNotes[noteId] = [];
@@ -114,7 +115,8 @@ export class TimelineProcessor {
 						path: notePath,
 						class: noteClass,
 						type: type,
-						endDate: endDate
+						endDate: endDate,
+						era: era
 					};
 					timelineDates.push(noteId);
 				} else {
@@ -127,7 +129,8 @@ export class TimelineProcessor {
 						path: notePath,
 						class: noteClass,
 						type: type,
-						endDate: endDate
+						endDate: endDate,
+						era: era
 					};
 				}
 			}
@@ -148,7 +151,11 @@ export class TimelineProcessor {
 			// Build the timeline html element
 			for (let date of timelineDates) {
 				let noteContainer = timeline.createDiv({ cls: 'timeline-container' });
-				let noteHeader = noteContainer.createEl('h2', { text: timelineNotes[date][0].date.replace(/-0*$/g, '').replace(/-0*$/g, '').replace(/-0*$/g, '') });
+				let dateText = timelineNotes[date][0].date.replace(/-0*$/g, '').replace(/-0*$/g, '').replace(/-0*$/g, '');
+				if (timelineNotes[date][0].era) {
+					dateText = dateText.concat(' ' + timelineNotes[date][0].era)
+				}
+				let noteHeader = noteContainer.createEl('h2', { text: dateText });
 				let eventContainer = noteContainer.createDiv({ cls: 'timeline-event-list', attr: { 'style': 'display: block' } });
 
 				noteHeader.addEventListener('click', event => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface CardContainer {
 	endDate: string;
 	type: string;
 	class: string;
+	era: string;
 }
 
 export type NoteData = CardContainer[];


### PR DESCRIPTION
## Era Display
Added the "era" data field to the span block. If specified, this will be appended to the date in the timeline display.

For example, this span would display in the timeline as "144-43-49-00 AB".
```
<span
	  class='ob-timelines'
	  data-date='144-43-49-00'
     data-era="AB"
>
```

## Remove `.md` from autofilled titles
When auto-filling the title based on the filename, remove the `.md` from the end. More in line with how other linking/embedding is displayed through obsidian.

## Dependency Update
Also updated the `package.json` to the latest standard for including the obsidian API. See https://github.com/obsidianmd/obsidian-api/issues/17.