### PR TITLE
Merge friendly pull of #44 and #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ tags: [timeline, test, me, now]
 
 2. The note must have all the specified tags to be included in the search. This note example above will be included in all of the following searches (assuming its timeline span info is valid): `test`, `test;me`, `test;me;now`, etc.
 
-3. The note must contain at least one timeline `span` or `div` element containing the event information, see the next sextion.
+3. The note must contain at least one timeline `span` or `div` element containing the event information, see the next section.
 
 When generating a timeline, a note will be ignored in the following cases:
 - The note does not have the `timeline` tag (the tag specified in plugin settings)

--- a/README.md
+++ b/README.md
@@ -152,11 +152,21 @@ For statically generated timelines, events that occur at the same time are group
   - If an invalid url is given, an empty black section will be seen for that note card
   - Currently only `http` & `absolute local path` will render. Obsidian release `v0.10.13` blocked obsidian links for background images. 
 
+### Era:
+  - Optional
+  - Adds this text to the date span in the timeline as an era designation. Useful for fictional calendars.
+  - Applied after the date is formatted. So `2300-00-00-00` with the era set to `AB` would display `2300 AB`.
+
 ### CSS Class:
   - Optional
   - Adds the applied css class to the note card associated with the timeline entry
 
 ## Release Notes
+
+### v0.3.3
+- Added optional span attribute 'era', allowing an era suffix to be displayed on the timeline.
+- Updated `package.json` to latest obsidian API standard.atch
+- Removes the `.md` extension when auto-filling the title 
 
 ### v0.2.1 
 - Remove escaping of `quotes / double quotes and ticks` from title and text (no longer needed)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Create the following code block where a timeline is to be inserted:
 
 ![example](https://raw.githubusercontent.com/Darakah/obsidian-timelines/main/images/example_1.png)
 
+You can also have an horizontal timeline by:
+
+1. Replacing `timeline` with `timeline-vis` in the code block,
+2. Add bellow filters:
+```timeline-vis
+tags=test
+startDate=1700
+endDate=2030
+fivHeight=600
+minDate=200
+```
+
 the render block takes a single input which is the list of tags by which to filter timeline tagged notes (e.g. in the above example block, ONLY notes with all three tags `timeline`, `test` and `now`).
 
 ### Using an HTML code block for static rendering

--- a/src/block.ts
+++ b/src/block.ts
@@ -50,7 +50,7 @@ export class TimelineProcessor {
 				if (e) {
 					let param = e.split('=');
 					if (param[1]) {
-						args[param[0]] = param[1]?.trim();
+						args:[param[0]] = param[1]?.trim();
 					}
 				}
 			});
@@ -157,7 +157,11 @@ export class TimelineProcessor {
 			// Build the timeline html element
 			for (let date of timelineDates) {
 				let noteContainer = timeline.createDiv({ cls: 'timeline-container' });
-				let noteHeader = noteContainer.createEl('h2', { text: timelineNotes[date][0].date.replace(/-0*$/g, '').replace(/-0*$/g, '').replace(/-0*$/g, '') });
+				let dateText = timelineNotes[date][0].date.replace(/-0*$/g, '').replace(/-0*$/g, '').replace(/-0*$/g, '');
+				if (timelineNotes[date][0].era) {
+						dateText = dateText.concat(' ' + timelineNotes[date][0].era)
+				}
+				let noteHeader = noteContainer.createEl('h2', { text: dateText });
 				let eventContainer = noteContainer.createDiv({ cls: 'timeline-event-list', attr: { 'style': 'display: block' } });
 
 				noteHeader.addEventListener('click', event => {

--- a/src/block.ts
+++ b/src/block.ts
@@ -98,11 +98,12 @@ export class TimelineProcessor {
 					continue;
 				}
 				// if not title is specified use note name
-				let noteTitle = event.dataset.title ?? file.name;
+				let noteTitle = event.dataset.title ?? file.name.replace(/\.md$/g, '')
 				let noteClass = event.dataset.class ?? "";
-				let notePath = '/' + file.path;
+				let notePath = event.dataset.path ?? '/' + file.path;
 				let type = event.dataset.type ?? "box";
 				let endDate = event.dataset.end ?? null;
+				let era = event.dataset.era ?? null;
 
 				if (!timelineNotes[noteId]) {
 					timelineNotes[noteId] = [];
@@ -114,7 +115,8 @@ export class TimelineProcessor {
 						path: notePath,
 						class: noteClass,
 						type: type,
-						endDate: endDate
+						endDate: endDate,
+						era: era
 					};
 					timelineDates.push(noteId);
 				} else {
@@ -126,7 +128,8 @@ export class TimelineProcessor {
 						path: notePath,
 						class: noteClass,
 						type: type,
-						endDate: endDate
+						endDate: endDate,
+						era: era
 					};
 					// if note_id already present prepend or append to it
 					if (settings.sortDirection) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface CardContainer {
 	endDate: string;
 	type: string;
 	class: string;
+	era: string;
 }
 
 export type NoteData = CardContainer[];


### PR DESCRIPTION
from https://github.com/Darakah/obsidian-timelines/pull/44#issue-1355010883 & https://github.com/Darakah/obsidian-timelines/pull/20#issue-952173288

### Era Display

Added the "era" data field to the span block. If specified, this will be appended to the date in the timeline display.

For example, this span would display in the timeline as "144-43-49-00 AB".

<span
    class='ob-timelines'
    data-date='144-43-49-00'
    data-era="AB"
>

### Enable alternative path

Enables the path field, allowing you to specify an alternative link path. EG "My Note#My Subhead" will create an internal link directly to the "My Subhead" header in #My Note. Especially useful when using page preview, as it allows you to preview more detailed information without leaving the timeline.
Remove .md from autofilled titles

When auto-filling the title based on the filename, remove the .md from the end. More in line with how other linking/embedding is displayed through obsidian.

### Package.json
needs to be updated, no need to use @https://github.com/obsidianmd/obsidian-api/tarball/master any. just use the version number of Obsidian